### PR TITLE
Fix reference to stern to point to new fork

### DIFF
--- a/documentation/modules/ROOT/pages/_partials/_setup.adoc
+++ b/documentation/modules/ROOT/pages/_partials/_setup.adoc
@@ -27,7 +27,7 @@ The following CLI tools are required for running the exercises in this tutorial.
 | https://kubernetes.io/docs/tasks/tools/install-kubectl/[Install]
 | https://kubernetes.io/docs/tasks/tools/install-kubectl/[Install]
 
-| https://github.com/wercker/stern[stern]
+| https://github.com/stern/stern[stern]
 | `brew install stern`
 | https://github.com/wercker/stern/releases/download/1.6.0/stern_linux_amd64[Download]
 | https://github.com/wercker/stern/releases/download/1.11.0/stern_windows_amd64.exe[Download]


### PR DESCRIPTION
The old link has not been updated since 2019, stern/stern is the new main repository.